### PR TITLE
set lower bounds for CUDAnative and CUDAdrv

### DIFF
--- a/REQUIRE
+++ b/REQUIRE
@@ -1,4 +1,4 @@
 julia 0.6
-CUDAnative
-CUDAdrv
+CUDAnative 0.4
+CUDAdrv 0.5
 CUBLAS


### PR DESCRIPTION
below which OwnedPtr didn't exist (https://github.com/JuliaGPU/CUDAdrv.jl/commit/ae1b22b0b8089d25a502df5d20f26e5798790684)
and DevicePtr wasn't in CUDAnative and didn't have a 1-arg constructor (https://github.com/JuliaGPU/CUDAnative.jl/commit/654fdd8caebed72f116568f8116ace0023e6a364)